### PR TITLE
Increment nucleic acid abbreviation counter for CMO samples

### DIFF
--- a/src/test/java/org/mskcc/cmo/metadb/PortedLimsRestCmoLabelGenerationTest.java
+++ b/src/test/java/org/mskcc/cmo/metadb/PortedLimsRestCmoLabelGenerationTest.java
@@ -56,7 +56,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.XENOGRAFT, NucleicAcid.DNA);
 
         String cmoId = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample, new ArrayList<>());
-        Assert.assertEquals("C-1235-X001-d", cmoId);
+        Assert.assertEquals("C-1235-X001-d01", cmoId);
     }
 
     /**
@@ -82,7 +82,35 @@ public class PortedLimsRestCmoLabelGenerationTest {
         List<SampleMetadata> existingSamples = Arrays.asList(existingSample);
 
         String cmoId = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample, existingSamples);
-        Assert.assertEquals("C-1235-X002-d", cmoId);
+        Assert.assertEquals("C-1235-X002-d02", cmoId);
+    }
+
+    /**
+     * Test CMO label generation for a patient with existing sample of same request,
+     * same igo id, same specimen type, and same nucleic acid.
+     * Returned label should be the CMO ID with number 2.
+     * This is the same test as directly above with the added nucleic acid abbreviation
+     * counter.
+     * Ported from test:
+     *   whenThereIsOnePatientSampleFromSameRequestWithCount1_shouldReturnCmoIdWithNumber2
+     * @throws Exception
+     */
+    @Test
+    public void testPatientOneExistingSampleNucAcidCounter() throws Exception {
+        String requestId = "5432_P";
+        String cmoPatientId = "C-1235";
+
+        IgoSampleManifest sample = getSampleMetadata("4324", cmoPatientId,
+                SpecimenType.XENOGRAFT, NucleicAcid.DNA);
+
+        String existingSampleId = "C-1235-X001-d01";
+        SampleMetadata existingSample = getSampleMetadataWithCmoLabel("5656",
+                cmoPatientId, "Xenograft", existingSampleId);
+        // get existing samples for given igo id and request id
+        List<SampleMetadata> existingSamples = Arrays.asList(existingSample);
+
+        String cmoId = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample, existingSamples);
+        Assert.assertEquals("C-1235-X002-d02", cmoId);
     }
 
     /**
@@ -100,14 +128,14 @@ public class PortedLimsRestCmoLabelGenerationTest {
         IgoSampleManifest sample = getSampleMetadata("4324", cmoPatientId,
                 SpecimenType.XENOGRAFT, NucleicAcid.DNA);
 
-        String existingSampleId = "C-1235-X012-d";
+        String existingSampleId = "C-1235-X012-d01";
         SampleMetadata existingSample = getSampleMetadataWithCmoLabel("5656",
                 cmoPatientId, "Xenograft", existingSampleId);
         // get existing samples for given igo id and request id
         List<SampleMetadata> existingSamples = Arrays.asList(existingSample);
 
         String cmoId = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample, existingSamples);
-        Assert.assertEquals("C-1235-X013-d", cmoId);
+        Assert.assertEquals("C-1235-X013-d02", cmoId);
     }
 
     /**
@@ -126,15 +154,17 @@ public class PortedLimsRestCmoLabelGenerationTest {
         IgoSampleManifest sample = getSampleMetadata("4324", cmoPatientId,
                 SpecimenType.PDX, NucleicAcid.RNA);
 
-        String existingSampleId = "C-1235-X001-d";
+        String existingSampleId = "C-1235-X001-d01";
         String diffRequestId = "1234_A";
         SampleMetadata existingSample = getSampleMetadataWithCmoLabel("5656",
                 cmoPatientId, "Xenograft", existingSampleId);
         // get existing samples for given igo id and request id
         List<SampleMetadata> existingSamples = Arrays.asList(existingSample);
 
+        // since nucleic acid abbreviation is different from existing sample, the
+        // nucleic acid counter is also '01'
         String cmoId = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample, existingSamples);
-        Assert.assertEquals("C-1235-X002-r", cmoId);
+        Assert.assertEquals("C-1235-X002-r01", cmoId);
     }
 
     /**
@@ -155,7 +185,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.XENOGRAFT, NucleicAcid.DNA);
         String cmoId1 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId,
                 sample1, new ArrayList<>());
-        Assert.assertEquals("C-1235-X001-d", cmoId1);
+        Assert.assertEquals("C-1235-X001-d01", cmoId1);
 
         // now we have one existing sample in this request for the same patient
         SampleMetadata existingSample = getSampleMetadataWithCmoLabel("4324_1",
@@ -166,7 +196,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
         IgoSampleManifest sample2 = getSampleMetadata("4324_2", cmoPatientId,
                 SpecimenType.XENOGRAFT, NucleicAcid.DNA);
         String cmoId2 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample2, existingSamples);
-        Assert.assertEquals("C-1235-X002-d", cmoId2);
+        Assert.assertEquals("C-1235-X002-d02", cmoId2);
     }
 
     /**
@@ -187,7 +217,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.XENOGRAFT, NucleicAcid.DNA);
         String cmoId1 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId,
                 sample1, new ArrayList<>());
-        Assert.assertEquals("C-1235-X001-d", cmoId1);
+        Assert.assertEquals("C-1235-X001-d01", cmoId1);
 
         // now we have one existing sample in this request for the same patient
         SampleMetadata existingSample = getSampleMetadataWithCmoLabel("4324_1",
@@ -198,7 +228,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
         IgoSampleManifest sample2 = getSampleMetadata("4324_2", cmoPatientId,
                 SpecimenType.XENOGRAFT, NucleicAcid.RNA);
         String cmoId2 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId, sample2, existingSamples);
-        Assert.assertEquals("C-1235-X002-r", cmoId2);
+        Assert.assertEquals("C-1235-X002-r01", cmoId2);
     }
 
     /**
@@ -220,7 +250,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.XENOGRAFT, NucleicAcid.DNA);
         String cmoId1 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId,
                 sample1, new ArrayList<>());
-        Assert.assertEquals("C-1235-X001-d", cmoId1);
+        Assert.assertEquals("C-1235-X001-d01", cmoId1);
 
         // now we have one existing sample in this request for the same patient
         SampleMetadata existingSample = getSampleMetadataWithCmoLabel("4324_1",
@@ -232,7 +262,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.PDX, NucleicAcid.DNA);
         String cmoId2 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId,
                 sample2, existingSamples);
-        Assert.assertEquals("C-1235-X002-d", cmoId2);
+        Assert.assertEquals("C-1235-X002-d02", cmoId2);
     }
 
     /**
@@ -253,7 +283,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.ORGANOID, NucleicAcid.DNA);
         String cmoId1 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId,
                 sample1, new ArrayList<>());
-        Assert.assertEquals("C-1235-G001-d", cmoId1);
+        Assert.assertEquals("C-1235-G001-d01", cmoId1);
 
         // now we have one existing sample in this request for the same patient
         SampleMetadata existingSample = getSampleMetadataWithCmoLabel("4324_1",
@@ -265,7 +295,7 @@ public class PortedLimsRestCmoLabelGenerationTest {
                 SpecimenType.ORGANOID, NucleicAcid.DNA);
         String cmoId2 = cmoLabelGeneratorService.generateCmoSampleLabel(requestId,
                 sample2, existingSamples);
-        Assert.assertEquals("C-1235-G002-d", cmoId2);
+        Assert.assertEquals("C-1235-G002-d02", cmoId2);
     }
 
     private SampleMetadata getSampleMetadataWithCmoLabel(String igoId, String cmoPatientId,


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

# Increment nucleic acid abbreviation counter for CMO samples

Briefly describe changes proposed in this pull request:

From investigator:

```
Counter: integer value incremented when the source is the same. (eg. if C-123456-T001-d is sequenced on Agilent Exome
and now the investigator wants to use the same sample with IDT, then we should have the sample labled C-123456-T001-
d02). Counter will be a 2 digit integer value range from 01-99 (values less < 10 are filled in with zeros '0' to preserve 2-digit
format). From the time of implementation the first sample for a particular Nucleic Acid get 01.
```

---

## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### I. Message handlers checklist:
- [n/a] ~~Changes introduced affect the workflow of incoming messages.~~
- [n/a] ~~Messages are following the expected workflow when published to the topic(s) changed or introduced in this pull request.~~
- [x] Unit tests were added or updated to ensure messages are handled as expected.

If no unit tests were updated or added, then please explain why: Unit tests were updated to meet the criteria for the new CMO label generation. A new unit test was added to ensure that the old format was also covered and would be updated to meet the new changes introduced in how the label is generated.

Please describe how the workflow and messaging was tested/simulated:

**Describe your testing environment:**

- NATS [**local**, local docker, dev server, production]
- Neo4j [**local**, local docker, dev server, production]
- MetaDB [**local**, local docker, dev server, production]
- ~~Message publishing simulation [nats cli, docker nats cli, metadb publisher tool, other (describe below)]~~

### II. Configuration and/or permissions checklist:
- [n/a] ~~New topics were introduced.~~
- [n/a] ~~The topics and appropriate permissions were updated in [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
- [n/a] ~~If applicable, a new account was set up and the account credentials and keys are checked into [cmo-metadb-configuration](https://github.mskcc.org/cmo/cmo-metadb-configuration).~~
- [n/a] ~~Account credentials and keys were shared with the appropriate parties.~~

---
### General checklist:
- [ ] All requested changes and comments have been resolved.
- [x] The commit log is comprehensible. It follows [7 rules of great commit messages](http://chris.beams.io/posts/git-commit/). For most PRs a single commit should suffice, in some cases multiple topical commits can be useful. During review it is ok to see tiny commits (e.g. Fix reviewer comments), but right before the code gets merged to master or rc branch, any such commits should be squashed since they are useless to the other developers. Definitely avoid [merge commits, use rebase instead.](http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-rebase/)
